### PR TITLE
App과 SSD 간의 Logger 동기화가 안되는 문제 수정

### DIFF
--- a/Logger/logger.cpp
+++ b/Logger/logger.cpp
@@ -32,7 +32,7 @@ class Logger {
         try {
             if (GetLogFileSize(_LOG_FILE) < MAX_LOG_FILE_SIZE) {
                 WriteToLogFile(_LOG_FILE, std::ios::app, logCommit);  // append
-                    return;
+                return;
             }
 
             CompressOldestFile();

--- a/Logger/logger.cpp
+++ b/Logger/logger.cpp
@@ -16,7 +16,6 @@ class Logger {
     void print(const char* funcName, const char* logMessage) {
         const unsigned int KB = 1000;
         const unsigned int MAX_LOG_FILE_SIZE = 10 * KB;
-        static std::string previousLogFile = "";
 
         time_t timer = time(NULL);
         tm nowTime;
@@ -33,12 +32,12 @@ class Logger {
         try {
             if (GetLogFileSize(_LOG_FILE) < MAX_LOG_FILE_SIZE) {
                 WriteToLogFile(_LOG_FILE, std::ios::app, logCommit);  // append
-                return;
+                    return;
             }
 
-            CompressOldestFile(previousLogFile);
+            CompressOldestFile();
 
-            previousLogFile = ChangeNameWithTimeStamp(nowTime);
+            ChangeNameWithTimeStamp(nowTime);
 
             WriteToLogFile(_LOG_FILE, std::ios::out, logCommit);  // overwrite
         }
@@ -49,9 +48,17 @@ class Logger {
 
  private:
     const char* _LOG_FILE;
+    const char* _OLD_FILE;
     Logger() {
         _LOG_FILE = "latest.log";
-        std::ofstream file(_LOG_FILE);
+        std::ofstream logfile;
+        logfile.open(_LOG_FILE, std::ios::app);
+        logfile.close();
+
+        _OLD_FILE = "oldest.txt";
+        std::ofstream flagfile;
+        logfile.open(_OLD_FILE, std::ios::app);
+        logfile.close();
     }
 
     int GetLogFileSize(const char* fileName) {
@@ -75,15 +82,32 @@ class Logger {
         writeFile << logContents;
     }
 
-    void CompressOldestFile(const std::string& oldfile) {
-        if (!oldfile.empty()) {
+    void CompressOldestFile() {
+        std::string oldfile;
+        if (IsExistPreviousOldFile(oldfile)) {
             std::string newFileName =
                 oldfile.substr(0, oldfile.find(".")) + std::string(".zip");
             int ret = rename(oldfile.c_str(), newFileName.c_str());
         }
     }
 
-    std::string ChangeNameWithTimeStamp(const tm& nowTime) {
+    int IsExistPreviousOldFile(std::string& oldFileName) {
+        std::ifstream readFile(_OLD_FILE);
+        if (!readFile.is_open()) {
+            throw std::runtime_error("[Error] failed to open readFile");
+        }
+
+        std::string stateAndName;
+        std::getline(readFile, stateAndName);
+        if (stateAndName.empty()) return 0;
+
+        int isOldFileExist = stoi(stateAndName.substr(0, stateAndName.find(" ")));
+        oldFileName = stateAndName.substr(stateAndName.find(" ")+1);
+
+        return isOldFileExist;
+    }
+
+    void ChangeNameWithTimeStamp(const tm& nowTime) {
         const unsigned int BUFFER_SIZE = 50;
         char over10KBLogFile[BUFFER_SIZE];
         sprintf_s(over10KBLogFile, BUFFER_SIZE,
@@ -91,6 +115,7 @@ class Logger {
             nowTime.tm_year - 100, nowTime.tm_mon + 1, nowTime.tm_mday,
             nowTime.tm_hour, nowTime.tm_min, nowTime.tm_sec);
         int ret = rename(_LOG_FILE, over10KBLogFile);
-        return over10KBLogFile;
+
+        WriteToLogFile(_OLD_FILE, std::ios::out, std::string("1 ") + std::string(over10KBLogFile));
     }
 };

--- a/Test_Shell_App/Main_Shell.cpp
+++ b/Test_Shell_App/Main_Shell.cpp
@@ -50,14 +50,17 @@ void FormatSSD(void) {
     deleteFileIfExists("nand.txt");
     deleteFileIfExists("result.txt");
     deleteFileIfExists("buffer.txt");
+    deleteFileIfExists("latest.log");
+    deleteFileIfExists("oldest.txt");
 }
 
-void CommandMode(void) {
+void CommandMode(void)
+{
+    FormatSSD();
     LOG_PRINT("Execute the input command being supported");
     Shell TestShellApp;
     TestShellApp.SetSsdDriver(new RealSsdDriver());
 
-    FormatSSD();
     string command;
     while (true) {
         cout << "> ";
@@ -72,8 +75,8 @@ void CommandMode(void) {
     }
 }
 
-void ScriptMode(char* argv[]) {
-    LOG_PRINT("Verify the script exists");
+void ScriptMode(char* argv[])
+{
     string inputArg = argv[1];
     string strRunListFile{ inputArg };
     ifstream runListFile(strRunListFile);
@@ -89,7 +92,6 @@ void ScriptMode(char* argv[]) {
 
 void RunScript(ifstream& runListFile)
 {
-    LOG_PRINT("Read the outer script");
     string strScriptFile;
 
     while (getline(runListFile, strScriptFile)) {
@@ -97,6 +99,7 @@ void RunScript(ifstream& runListFile)
         Shell TestShellApp;
         TestShellApp.SetSsdDriver(new RealSsdDriver());
         FormatSSD();
+        LOG_PRINT("execute the script in the 'run_list'");
 
         if (scriptFile.is_open()) {
             stringstream actualOutput;

--- a/virtual_SSD/Parser.cpp
+++ b/virtual_SSD/Parser.cpp
@@ -1,6 +1,7 @@
 // Copyright [2024] <CRA/BestReviewer>
 #include<stdexcept>
 #include"Parser.h"
+#include "../Logger/logger.cpp"
 
 class ArgsLengthNotMatchException : public std::exception {};
 
@@ -10,6 +11,7 @@ CmdStatus *Parser::Parse(const std::string &strCommand) {
 }
 
 void Parser::TokenArgument(const std::string& strCommand) {
+    LOG_PRINT("Separate commands into tokens");
     std::string token;
     size_t start = strCommand.find(' ', 0) + 1;
     size_t end = start;
@@ -25,6 +27,7 @@ void Parser::TokenArgument(const std::string& strCommand) {
 }
 
 CmdStatus* Parser::UpdateCmdStatus() {
+    LOG_PRINT("Generate the appropriate command : W/R/E/F");
     if (CommandToken[0] == WRITE_CMD) return UpdateWriteCmdStatus();
     else if (CommandToken[0] == READ_CMD) return UpdateReadCmdStatus();
     else if (CommandToken[0] == ERASE_CMD) return UpdateEraseCmdStatus();

--- a/virtual_SSD/SSD.cpp
+++ b/virtual_SSD/SSD.cpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 #include"SSD.h"
+#include "../Logger/logger.cpp"
 
 class LBARangeException : public std::exception {};
 class DataRangeException : public std::exception {};
@@ -73,7 +74,8 @@ bool SSD::IsInLBA(const int& LBA, CmdContent& bufferData) {
     return LBA >= bufferData.LBA && LBA < (bufferData.LBA + bufferData.LBASize);
 }
 
-void SSD::StoreCommand(const int& LBA, const std::string& data, const int& size) {
+void SSD::StoreCommand(const int& LBA, const std::string data, const int& size) {
+    LOG_PRINT("store new cmd into 'Command Buffer'");
     std::vector<std::string> lines = ReadFile(CommandBufferFileName);
     lines.push_back(std::to_string(LBA) + " " + data + " " + std::to_string(size));
     WriteFile(CommandBufferFileName, lines);

--- a/virtual_SSD/SSD.cpp
+++ b/virtual_SSD/SSD.cpp
@@ -74,7 +74,7 @@ bool SSD::IsInLBA(const int& LBA, CmdContent& bufferData) {
     return LBA >= bufferData.LBA && LBA < (bufferData.LBA + bufferData.LBASize);
 }
 
-void SSD::StoreCommand(const int& LBA, const std::string data, const int& size) {
+void SSD::StoreCommand(const int& LBA, const std::string& data, const int& size) {
     LOG_PRINT("store new cmd into 'Command Buffer'");
     std::vector<std::string> lines = ReadFile(CommandBufferFileName);
     lines.push_back(std::to_string(LBA) + " " + data + " " + std::to_string(size));

--- a/virtual_SSD/SSDCommand.cpp
+++ b/virtual_SSD/SSDCommand.cpp
@@ -4,6 +4,7 @@
 #include "SSD.h"
 #include "Parser.h"
 #include "SSDInterface.h"
+#include "../Logger/logger.cpp"
 
 void SSDCommand::Run(const std::string& strCommand) {
     cmd = parser->Parse(strCommand);
@@ -20,17 +21,21 @@ void SSDCommand::Run(const std::string& strCommand) {
 }
 
 void SSDCommand::_Write() {
+    LOG_PRINT("send W cmd");
     ssd->Write(stoi(cmd->LBA), cmd->LBAData);
 }
 
 void SSDCommand::_Read() {
+    LOG_PRINT("send R cmd");
     ssd->Read(stoi(cmd->LBA));
 }
 
 void SSDCommand::_Erase() {
+    LOG_PRINT("send E cmd");
     ssd->Erase(stoi(cmd->LBA), cmd->EraseSize);
 }
 
 void SSDCommand::_Flush() {
+    LOG_PRINT("send F cmd");
     ssd->Flush();
 }


### PR DESCRIPTION
## 개요
기존에는 App.exe, SSD.exe 실행 할때마다 Logger인스턴스가 1개 실행되고, latest.log 파일이 새로 만들어진다.
App.exe에서는 SSD.exe를 system 함수로 실행시키는데 latest.log가 업데이트가 안되고 매번 새로 만들어지는 버그가 있었다.
SSDFormat()호출 시에 latest.log를 삭제하게 만들고, Logger 인스턴스는 latest.log를 append 형태로 open and close한다.
SSD.exe는 매번 실행될때마다 이전 log파일의 정보가 초기화되기 때문에 oldest.txt라는 파일을 두어서 여기에 파일정보에 대한 상태를 기록해두고, latest.log가 10KB가 초과될때마다 oldest.txt를 참고한다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
